### PR TITLE
Trim extra whitespace when getting original text

### DIFF
--- a/trunk8.js
+++ b/trunk8.js
@@ -25,7 +25,7 @@
 	
 	function trunk8(element) {
 		this.$element = $(element);
-		this.original_text = this.$element.html();
+		this.original_text = this.$element.html().trim();
 		this.settings = $.extend({}, $.fn.trunk8.defaults);
 	}
 	


### PR DESCRIPTION
I have a situation where I'm using a template to render html, then using trunk8 on the html.  In my html template:

``` html
<div class='to-be-truncated'>
    {{insert_data_into_template}}
</div>
```

Note the newlines.  I did NOT have that whole div on one line.  Because of that, trunk8 inserted a tooltip with those extra newlines as well.  Of course, I ended up just putting my entire div on one line to fix the issue.  But I figured I'd submit this PR anyway.  It might be useful to others.  So, I trimmed out the extra newlines.  What do you guys think?  
