### PR TITLE
word boundary feature

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -158,15 +158,14 @@ $(document).ready(function () {
 
 	$('#words').click(function () {
 		var settings = $('#txt').trunk8('getSettings');
-        if( typeof settings.wordBoundary === 'string' ) {
-          settings.wordBoundary = undefined;
-          $('#words').html('Word Boundary: " "');
-
-        }
-        else {
-          settings.wordBoundary = ' ' ;
-          $('#words').html('Word Boundary: undefined');
-        }
+		if( typeof settings.wordBoundary === 'string' ) {
+		      settings.wordBoundary = undefined;
+		      $('#words').html('Word Boundary: " "');
+		}
+		else {
+		      settings.wordBoundary = ' ' ;
+		      $('#words').html('Word Boundary: undefined');
+		}
 
 		$('#txt').trunk8({wordBoundary: settings.wordBoundary});
 		updateSettings(settings);

--- a/trunk8.js
+++ b/trunk8.js
@@ -196,27 +196,19 @@
 			this.html('');
 			
 			/* Display the biggest bite. */
-            if( typeof wordBoundary === 'string' ) {
-                var index = max_bite.length - fill.length - 1;
+			if( typeof wordBoundary === 'string' ) {
+				var index = max_bite.length - fill.length - 1;
 
-                console.debug('index: ' + index + ' is ' +
-                    max_bite.charAt(index))
+				while(wordBoundary.indexOf(max_bite.charAt(index))) {
+					index -= 1
+					if( index == 0 ) {
+						break;
+					}
+				}
 
-                var test = wordBoundary.indexOf(max_bite.charAt(index))
-                while(test == -1) {
-                    index -= 1
-                    if( index == 0 ) {
-                        break;
-                    }
-
-                    console.debug('index: ' + index + ' is ' +
-                        max_bite.charAt(index))
-                    test = wordBoundary.indexOf(max_bite.charAt(index))
-                }
-
-                max_bite = max_bite.substring(0, index);
-                max_bite += fill;
-            }
+				max_bite = max_bite.substring(0, index);
+				max_bite += fill;
+			}
 			this.html(max_bite);
 			
 			if (settings.tooltip) {


### PR DESCRIPTION
- added word boundary checking after the bite search …
- trunk8 now takes an optional "wordBoundary" parameter that would be a string
  containing any value that you want to use as a word boundary

example:

$('too-long').trunk8({
    wordBoundary:' -',
});

The above would use space or hyphen as a word boundary and after the bite
search is run backs the string up until it finds a boundary character.
