### PR TITLE
fix(jquery-trunk8): Fix cross-browser compatibility issue with stripping HTML

### DIFF
--- a/trunk8.js
+++ b/trunk8.js
@@ -36,7 +36,12 @@
 	function stripHTML(html) {
 		var tmp = document.createElement("DIV");
 		tmp.innerHTML = html;
-		return tmp.textContent||tmp.innerText;
+		
+		if (typeof tmp.textContent != 'undefined') {
+			return tmp.textContent;
+		}
+
+		return tmp.innerText
 	}
 
 	function getHtmlArr(str) {


### PR DESCRIPTION
Internet Explorer introduced element.innerText a while back which retrieves the text from a DOM node. All other major browsers have agreed to use Node.textContent instead. While most of them also support element.innerText, Firefox does not.

The trunk8 plugin for jQuery uses the check tmp.textContent || tmp.innerText to retrieve the text from a given node. This won't work in Firefox when `tmp` has no content -- specifically when `html` is an empty string -- because `tmp.textContent` returns `""` (an empty string, which is falsey in JavaScript) and `tmp.innerText` returns `undefined`. Because of JavaScript's short circuiting feature, the expression `tmp.textContent || tmp.innerText` then returns `undefined`. This caused an error in one code  which ultimately resulted in the page not rendering entirely.

This fix checks to see whether the browser supports Node.textContent and, if so, returns `tmp.textContent`. Otherwise, return `tmp.innerText`.
