### PR TITLE
Added onTruncate init parameter / success function

### DIFF
--- a/trunk8.js
+++ b/trunk8.js
@@ -140,7 +140,6 @@
 			fill = settings.fill,
 			parseHTML = settings.parseHTML,
 			line_height = utils.getLineHeight(this) * settings.lines,
-			onTruncate = settings.onTruncate,
 			str = data.original_text,
 			length = str.length,
 			max_bite = '',
@@ -222,7 +221,7 @@
 			$.error('Invalid width "' + width + '".');
 			return;
 		}
-		onTruncate();
+		settings.onTruncate();
 	}
 
 	methods = {


### PR DESCRIPTION
onTruncate can be passed at initialization time. It is a function that will
fire if trunk8 _does_ actually truncate the text. If trunk8 _does not_
truncate the text, the passed function will not fire.

This is useful if the front-end needs to be modified / decorated in some
custom manner when trunk8 successfully truncates text but left alone
when there is no truncation.
