### PR TITLE
Use jQuery.trim() instead

### DIFF
--- a/trunk8.js
+++ b/trunk8.js
@@ -25,7 +25,7 @@
 	
 	function trunk8(element) {
 		this.$element = $(element);
-		this.original_text = this.$element.html().trim();
+		this.original_text = $.trim(this.$element.html());
 		this.settings = $.extend({}, $.fn.trunk8.defaults);
 	}
 	


### PR DESCRIPTION
Internet Explorer 8 or lower doesn't support .trim() so, we use jQuery.trim() instead.
