### PR TITLE
use jquery.actual to compute height of target element

### DIFF
--- a/trunk8.jquery.json
+++ b/trunk8.jquery.json
@@ -12,7 +12,8 @@
 		"url": "https://raw.github.com/rviscomi/trunk8/master/LICENSE"
 	}],
 	"dependencies": {
-		"jquery": ">=1"
+		"jquery": ">=1",
+		"jquery.actual": ">=1"
 	},
 	"description": "trunk8 is an intelligent text truncation plugin to jQuery. When applied to a large block of text, trunk8 will cut off just enough text to prevent it from spilling over. Unlike conventional truncation that just limits the character length of text, trunk8 measures the content area for spill-over and intelligently chooses the text that best fits in the given space.",
 	"keywords": [

--- a/trunk8.js
+++ b/trunk8.js
@@ -1,10 +1,10 @@
 /**!
  * trunk8 v1.3.3
  * https://github.com/rviscomi/trunk8
- * 
+ *
  * Copyright 2012 Rick Viscomi
  * Released under the MIT License.
- * 
+ *
  * Date: September 26, 2012
  */
 
@@ -22,13 +22,13 @@
 		WIDTH = {
 			auto: 'auto'
 		};
-	
+
 	function trunk8(element) {
 		this.$element = $(element);
 		this.original_text = $.trim(this.$element.html());
 		this.settings = $.extend({}, $.fn.trunk8.defaults);
 	}
-	
+
 	trunk8.prototype.updateSettings = function (options) {
 		this.settings = $.extend(this.settings, options);
 	};
@@ -36,7 +36,7 @@
 	function stripHTML(html) {
 		var tmp = document.createElement("DIV");
 		tmp.innerHTML = html;
-		
+
 		if (typeof tmp.textContent != 'undefined') {
 			return tmp.textContent;
 		}
@@ -148,7 +148,7 @@
 			bite,
 			text,
 			htmlObject;
-		
+
 		/* Reset the field to the original string. */
 		this.html(str);
 		text = this.text();
@@ -163,7 +163,7 @@
 
 		if (width === WIDTH.auto) {
 			/* Assuming there is no "overflow: hidden". */
-			if (this.height() <= line_height) {
+			if (this.actual('height') <= line_height) {
 				/* Text is already at the optimal trunkage. */
 				return;
 			}
@@ -175,17 +175,17 @@
 
 			while (lower <= upper) {
 				bite_size = lower + ((upper - lower) >> 1);
-				
+
 				bite = utils.eatStr(str, side, length - bite_size, fill);
 
 				if (parseHTML && htmlObject) {
 					bite = rebuildHtmlFromBite(bite, htmlObject, fill);
 				}
-				
+
 				this.html(bite);
 
 				/* Check for overflow. */
-				if (this.height() > line_height) {
+				if (this.actual('height') > line_height) {
 					upper = bite_size - 1;
 				}
 				else {
@@ -198,10 +198,10 @@
 
 			/* Reset the content to eliminate possible existing scroll bars. */
 			this.html('');
-			
+
 			/* Display the biggest bite. */
 			this.html(max_bite);
-			
+
 			if (settings.tooltip) {
 				this.attr('title', text);
 			}
@@ -212,7 +212,7 @@
 			bite = utils.eatStr(str, side, bite_size, fill);
 
 			this.html(bite);
-			
+
 			if (settings.tooltip) {
 				this.attr('title', str);
 			}
@@ -229,13 +229,13 @@
 			return this.each(function () {
 				var $this = $(this),
 					data = $this.data('trunk8');
-				
+
 				if (!data) {
 					$this.data('trunk8', (data = new trunk8(this)));
 				}
-				
+
 				data.updateSettings(options);
-				
+
 				truncate.call($this);
 			});
 		},
@@ -244,7 +244,7 @@
 		update: function (new_string) {
 			return this.each(function () {
 				var $this = $(this);
-				
+
 				/* Update text. */
 				if (new_string) {
 					$this.data('trunk8').original_text = new_string;
@@ -254,12 +254,12 @@
 				truncate.call($this);
 			});
 		},
-		
+
 		revert: function () {
 			return this.each(function () {
 				/* Get original text. */
 				var text = $(this).data('trunk8').original_text;
-				
+
 				/* Revert element to original text. */
 				$(this).html(text);
 			});
@@ -283,7 +283,7 @@
 			if (utils.eatStr.cache[key]) {
 				return utils.eatStr.cache[key];
 			}
-			
+
 			/* Common error handling. */
 			if ((typeof str !== 'string') || (length === 0)) {
 				$.error('Invalid source string "' + str + '".');
@@ -305,12 +305,12 @@
 					/* str... */
 					return utils.eatStr.cache[key] =
 							$.trim(str.substr(0, length - bite_size)) + fill;
-					
+
 				case SIDES.left:
 					/* ...str */
 					return utils.eatStr.cache[key] =
 							fill + $.trim(str.substr(bite_size));
-					
+
 				case SIDES.center:
 					/* Bit-shift to the right by one === Math.floor(x / 2) */
 					half_length = length >> 1; // halve the length
@@ -321,12 +321,12 @@
 							$.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
 							fill +
 							$.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
-					
+
 				default:
 					$.error('Invalid side "' + side + '".');
 			}
 		},
-		
+
 		getLineHeight: function (elem) {
 				var floats = $(elem).css('float');
 				if (floats !== 'none') {
@@ -336,20 +336,20 @@
 				if (pos === 'absolute') {
 					$(elem).css('position', 'static');
 				}
-	
+
 				var html = $(elem).html(),
 				wrapper_id = 'line-height-test',
 				line_height;
-	
+
 				/* Set the content to a small single character and wrap. */
 				$(elem).html('i').wrap('<div id="' + wrapper_id + '" />');
-	
+
 				/* Calculate the line height by measuring the wrapper.*/
 				line_height = $('#' + wrapper_id).innerHeight();
-	
+
 				/* Remove the wrapper and reset the content. */
 				$(elem).html(html).css({ 'float': floats, 'position': pos }).unwrap();
-	
+
 				return line_height;
 			}
 	};
@@ -358,7 +358,7 @@
 	utils.eatStr.generateKey = function () {
 		return Array.prototype.join.call(arguments, '');
 	};
-	
+
 	$.fn.trunk8 = function (method) {
 		if (methods[method]) {
 			return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
@@ -370,7 +370,7 @@
 			$.error('Method ' + method + ' does not exist on jQuery.trunk8');
 		}
 	};
-	
+
 	/* Default trunk8 settings. */
 	$.fn.trunk8.defaults = {
 		fill: '&hellip;',

--- a/trunk8.js
+++ b/trunk8.js
@@ -345,7 +345,7 @@
 				$(elem).html('i').wrap('<div id="' + wrapper_id + '" />');
 
 				/* Calculate the line height by measuring the wrapper.*/
-				line_height = $('#' + wrapper_id).innerHeight();
+				line_height = $('#' + wrapper_id).actual('height');
 
 				/* Remove the wrapper and reset the content. */
 				$(elem).html(html).css({ 'float': floats, 'position': pos }).unwrap();


### PR DESCRIPTION
I added a dependency on [jquery.actual plugin](https://github.com/dreamerslab/jquery.actual), and use it to compute height of target, even if not displayed.

The height of a hidden element is 0, but with the plugin the actual height can be detected.