### PR TITLE
Add support for working with rendered content to remove the page 'jumps' after truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,41 @@ $('.too-long').trunk8('update', new_string); // Lorem ipsum dolor sit amet, cons
 
 To invoke built-in trunk8 methods, supply the method name as a string. Method arguments are listed after the method name as necessary. See the section below entitled Methods for a full specification.
 
+**Pre-Rendered Content**
+
+To use trunk8 without the jumpy behavior when the page finishes loading and truncation has been completed, add an `overflow-y: hidden` and fixed height to the element that needs to be truncated. Also add a hidden class if you don't have that already.
+
+```css
+.overflow-hidden {
+    overflow-y: hidden;
+    height: 4.5em;
+}
+
+.hidden {
+    display: none !important;
+}
+```
+You can use LESS or SASS to calculate the height based on the number of lines that you set in trunk8. For example:
+* the number of lines shown after truncation is 3
+* the line-height on your page or the element that needs truncation is 1.5em
+
+Height of your overflow-hidden element will be `3 * 1.5em = 4.5em`.
+
+Add a dummy element that is used by trunk8 to calculate the truncation (as this doesn't work on elements with `overflow-y: hidden`)
+```html
+<p class="overflow-hidden">Very long text</p>
+<p class="truncate hidden"></p>
+```
+
+Set the overflow-hidden element in the trunk8 settings
+```js
+var options = {
+    usePreRenderElement: true,
+    preRenderElement: $('p.overflow-hidden');
+}
+$('p.truncate').trunk8(options);
+```
+
 **Custom Settings**
 ```js
 $('.too-long').trunk8({
@@ -48,6 +83,8 @@ Settings
 * **tooltip** _(Default: `true`)_ When true, the `title` attribute of the targeted HTML element will be set to the original, untruncated string. Valid values include `true` and `false`.
 * **width** _(Default: `'auto'`)_ The width, in characters, of the desired text. When set to `'auto'`, trunk8 will maximize the amount of text without spilling over.
 * **parseHTML** _(Default: `'false'`)_ When true, parse and save html structure and restore structure in the truncated text.
+* **usePreRenderElement** _(Default: `'false'`)_ When true, enable pre-render functionality.
+* **preRenderElement** _(Default: `'undefined'`)_ When set, this is the element that contains the content and will be updated with the truncated content once it's done.
 * **onTruncate** _(Callback)_: Called after truncation is completed.
 
 Public Methods

--- a/trunk8.js
+++ b/trunk8.js
@@ -1,384 +1,431 @@
 /**!
  * trunk8 v1.3.3
  * https://github.com/rviscomi/trunk8
- * 
+ *
  * Copyright 2012 Rick Viscomi
  * Released under the MIT License.
- * 
+ *
  * Date: September 26, 2012
  */
 
 (function ($) {
-	var methods,
-		utils,
-		SIDES = {
-			/* cen...ter */
-			center: 'center',
-			/* ...left */
-			left: 'left',
-			/* right... */
-			right: 'right'
-		},
-		WIDTH = {
-			auto: 'auto'
-		};
-	
-	function trunk8(element) {
-		this.$element = $(element);
-		this.original_text = $.trim(this.$element.html());
-		this.settings = $.extend({}, $.fn.trunk8.defaults);
-	}
-	
-	trunk8.prototype.updateSettings = function (options) {
-		this.settings = $.extend(this.settings, options);
-	};
+    var methods,
+        utils,
+        SIDES = {
+            /* cen...ter */
+            center: 'center',
+            /* ...left */
+            left: 'left',
+            /* right... */
+            right: 'right'
+        },
+        WIDTH = {
+            auto: 'auto'
+        };
 
-	function stripHTML(html) {
-		var tmp = document.createElement("DIV");
-		tmp.innerHTML = html;
-		
-		if (typeof tmp.textContent != 'undefined') {
-			return tmp.textContent;
-		}
+    function trunk8(element) {
+        this.$element = $(element);
+        this.original_text = this.$element.html().trim();
+        this.settings = $.extend({}, $.fn.trunk8.defaults);
+    }
 
-		return tmp.innerText
-	}
+    trunk8.prototype.updateSettings = function (options) {
+        this.settings = $.extend(this.settings, options);
+    };
 
-	function getHtmlArr(str) {
-		/* Builds an array of strings and designated */
-		/* HTML tags around them. */
-		if (stripHTML(str) === str) {
-			return str.split(/\s/g);
-		}
-		var allResults = [],
-			reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>))<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
-			outArr = reg.exec(str),
-			lastI,
-			ind;
-		while (outArr && lastI !== reg.lastIndex) {
-			lastI = reg.lastIndex;
-			if (outArr[5]) {
-				allResults.push(outArr[5]);
-			} else if (outArr[1]) {
-				allResults.push({
-					tag: outArr[1],
-					attribs: outArr[2],
-					content: outArr[3],
-					after: outArr[4]
-				});
-			}
-			outArr = reg.exec(str);
-		}
-		for (ind = 0; ind < allResults.length; ind++) {
-			if (typeof allResults[ind] !== 'string' &&
-					allResults[ind].content) {
-				allResults[ind].content = getHtmlArr(allResults[ind].content);
-			}
-		}
-		return allResults;
-	}
+    function stripHTML(html) {
+        var tmp = document.createElement("DIV");
+        tmp.innerHTML = html;
 
-	function rebuildHtmlFromBite(bite, htmlObject, fill) {
-		// Take the processed bite after binary-search
-		// truncated and re-build the original HTML
-		// tags around the processed string.
-		bite = bite.replace(fill, '');
+        if (typeof tmp.textContent != 'undefined') {
+            return tmp.textContent;
+        }
 
-		var biteHelper = function(contentArr, tagInfo) {
-				var retStr = '',
-					content,
-					biteContent,
-					biteLength,
-					nextWord,
-					i;
-				for (i = 0; i < contentArr.length; i++) {
-					content = contentArr[i];
-					biteLength = $.trim(bite).split(' ').length;
-					if ($.trim(bite).length) {
-						if (typeof content === 'string') {
-							if (!/<br\s*\/?>/i.test(content)) {
-								if (biteLength === 1 && $.trim(bite).length <= content.length) {
-									content = bite;
-									// We want the fill to go inside of the last HTML
-									// element if the element is a container.
-									if (tagInfo === 'p' || tagInfo === 'div') {
-										content += fill;
-									}
-									bite = '';
-								} else {
-									bite = bite.replace(content, '');
-								}
-							}
-							retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
-						} else {
-							biteContent = biteHelper(content.content, content.tag);
-							if (content.after) bite = bite.replace(content.after, '');
-							if (biteContent) {
-								if (!content.after) content.after = ' ';
-								retStr += '<'+content.tag+content.attribs+'>'+biteContent+'</'+content.tag+'>' + content.after;
-							}
-						}
-					}
-				}
-				return retStr;
-			},
-			htmlResults = biteHelper(htmlObject);
+        return tmp.innerText
+    }
 
-		// Add fill if doesn't exist. This will place it outside the HTML elements.
-		if (htmlResults.slice(htmlResults.length - fill.length) === fill) {
-			htmlResults += fill;
-		}
+    function getHtmlArr(str) {
+        /* Builds an array of strings and designated */
+        /* HTML tags around them. */
+        if (stripHTML(str) === str) {
+            return str.split(/\s/g);
+        }
+        var allResults = [],
+            reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>)*)<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
+            outArr = reg.exec(str),
+            lastI,
+            ind;
+        while (outArr && lastI !== reg.lastIndex) {
+            lastI = reg.lastIndex;
+            if (outArr[5]) {
+                allResults.push(outArr[5]);
+            } else if (outArr[1]) {
+                allResults.push({
+                    tag: outArr[1],
+                    attribs: outArr[2],
+                    content: outArr[3],
+                    after: outArr[4]
+                });
+            }
+            outArr = reg.exec(str);
+        }
+        for (ind = 0; ind < allResults.length; ind++) {
+            if (typeof allResults[ind] !== 'string' &&
+                allResults[ind].content) {
+                allResults[ind].content = getHtmlArr(allResults[ind].content);
+            }
+        }
+        return allResults;
+    }
 
-		return htmlResults;
-	}
+    function rebuildHtmlFromBite(bite, htmlObject, fill) {
+        // Take the processed bite after binary-search
+        // truncated and re-build the original HTML
+        // tags around the processed string.
+        bite = bite.replace(fill, '');
 
-	function truncate() {
-		var data = this.data('trunk8'),
-			settings = data.settings,
-			width = settings.width,
-			side = settings.side,
-			fill = settings.fill,
-			parseHTML = settings.parseHTML,
-			line_height = utils.getLineHeight(this) * settings.lines,
-			str = data.original_text,
-			length = str.length,
-			max_bite = '',
-			lower, upper,
-			bite_size,
-			bite,
-			text,
-			htmlObject;
-		
-		/* Reset the field to the original string. */
-		this.html(str);
-		text = this.text();
+        var biteHelper = function(contentArr, tagInfo) {
+                var retStr = '',
+                    content,
+                    biteContent,
+                    biteLength,
+                    nextWord,
+                    i;
+                for (i = 0; i < contentArr.length; i++) {
+                    content = contentArr[i];
+                    biteLength = $.trim(bite).split(' ').length;
+                    if ($.trim(bite).length) {
+                        if (typeof content === 'string') {
+                            if (!/<br\s*\/?>/.test(content)) {
+                                if (biteLength === 1 && $.trim(bite).length <= content.length) {
+                                    content = bite;
+                                    // We want the fill to go inside of the last HTML
+                                    // element if the element is a container.
+                                    if (tagInfo === 'p' || tagInfo === 'div') {
+                                        content += fill;
+                                    }
+                                    bite = '';
+                                } else {
+                                    bite = bite.replace(content, '');
+                                }
+                            }
+                            retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
+                        } else {
+                            biteContent = biteHelper(content.content, content.tag);
+                            if (content.after) bite = bite.replace(content.after, '');
+                            if (biteContent) {
+                                if (!content.after) content.after = ' ';
+                                retStr += '<'+content.tag+content.attribs+'>'+biteContent+'</'+content.tag+'>' + content.after;
+                            }
+                        }
+                    }
+                }
+                return retStr;
+            },
+            htmlResults = biteHelper(htmlObject);
 
-		/* If string has HTML and parse HTML is set, build */
-		/* the data struct to house the tags */
-		if (parseHTML && stripHTML(str) !== str) {
-			htmlObject = getHtmlArr(str);
-			str = stripHTML(str);
-			length = str.length;
-		}
+        // Add fill if doesn't exist. This will place it outside the HTML elements.
+        if (htmlResults.slice(htmlResults.length - fill.length) === fill) {
+            htmlResults += fill;
+        }
 
-		if (width === WIDTH.auto) {
-			/* Assuming there is no "overflow: hidden". */
-			if (this.height() <= line_height) {
-				/* Text is already at the optimal trunkage. */
-				return;
-			}
+        return htmlResults;
+    }
 
-			/* Binary search technique for finding the optimal trunkage. */
-			/* Find the maximum bite without overflowing. */
-			lower = 0;
-			upper = length - 1;
+    function truncate() {
+        var data = this.data('trunk8'),
+            settings = data.settings,
+            width = settings.width,
+            side = settings.side,
+            fill = settings.fill,
+            parseHTML = settings.parseHTML,
+            line_height = utils.getLineHeight(this) * settings.lines,
+            str = data.original_text,
+            length = str.length,
+            max_bite = '',
+            lower, upper,
+            bite_size,
+            bite,
+            text,
+            htmlObject;
 
-			while (lower <= upper) {
-				bite_size = lower + ((upper - lower) >> 1);
-				
-				bite = utils.eatStr(str, side, length - bite_size, fill);
+        /* Reset the field to the original string. */
+        this.html(str);
+        text = this.text();
 
-				if (parseHTML && htmlObject) {
-					bite = rebuildHtmlFromBite(bite, htmlObject, fill);
-				}
-				
-				this.html(bite);
+        /* If string has HTML and parse HTML is set, build */
+        /* the data struct to house the tags */
+        if (parseHTML && stripHTML(str) !== str) {
+            htmlObject = getHtmlArr(str);
+            str = stripHTML(str);
+            length = str.length;
+        }
 
-				/* Check for overflow. */
-				if (this.height() > line_height) {
-					upper = bite_size - 1;
-				}
-				else {
-					lower = bite_size + 1;
+        if (width === WIDTH.auto) {
+            /* Assuming there is no "overflow: hidden". */
+            if (utils.getHeight(this) <= line_height) {
+                /* Text is already at the optimal trunkage. */
+                return;
+            }
 
-					/* Save the bigger bite. */
-					max_bite = (max_bite.length > bite.length) ? max_bite : bite;
-				}
-			}
+            /* Binary search technique for finding the optimal trunkage. */
+            /* Find the maximum bite without overflowing. */
+            lower = 0;
+            upper = length - 1;
 
-			/* Reset the content to eliminate possible existing scroll bars. */
-			this.html('');
-			
-			/* Display the biggest bite. */
-			this.html(max_bite);
-			
-			if (settings.tooltip) {
-				this.attr('title', text);
-			}
-		}
-		else if (!isNaN(width)) {
-			bite_size = length - width;
+            while (lower <= upper) {
+                bite_size = lower + ((upper - lower) >> 1);
 
-			bite = utils.eatStr(str, side, bite_size, fill);
+                bite = utils.eatStr(str, side, length - bite_size, fill);
 
-			this.html(bite);
-			
-			if (settings.tooltip) {
-				this.attr('title', str);
-			}
-		}
-		else {
-			$.error('Invalid width "' + width + '".');
-			return;
-		}
-		settings.onTruncate();
-	}
+                if (parseHTML && htmlObject) {
+                    bite = rebuildHtmlFromBite(bite, htmlObject, fill);
+                }
 
-	methods = {
-		init: function (options) {
-			return this.each(function () {
-				var $this = $(this),
-					data = $this.data('trunk8');
-				
-				if (!data) {
-					$this.data('trunk8', (data = new trunk8(this)));
-				}
-				
-				data.updateSettings(options);
-				
-				truncate.call($this);
-			});
-		},
+                this.html(bite);
 
-		/** Updates the text value of the elements while maintaining truncation. */
-		update: function (new_string) {
-			return this.each(function () {
-				var $this = $(this);
-				
-				/* Update text. */
-				if (new_string) {
-					$this.data('trunk8').original_text = new_string;
-				}
+                /* Check for overflow. */
+                if (utils.getHeight(this) > line_height) {
+                    upper = bite_size - 1;
+                }
+                else {
+                    lower = bite_size + 1;
 
-				/* Truncate accordingly. */
-				truncate.call($this);
-			});
-		},
-		
-		revert: function () {
-			return this.each(function () {
-				/* Get original text. */
-				var text = $(this).data('trunk8').original_text;
-				
-				/* Revert element to original text. */
-				$(this).html(text);
-			});
-		},
+                    /* Save the bigger bite. */
+                    max_bite = (max_bite.length > bite.length) ? max_bite : bite;
+                }
+            }
 
-		/** Returns this instance's settings object. NOT CHAINABLE. */
-		getSettings: function () {
-			return $(this.get(0)).data('trunk8').settings;
-		}
-	};
+            /* Reset the content to eliminate possible existing scroll bars. */
+            this.html('');
 
-	utils = {
-		/** Replaces [bite_size] [side]-most chars in [str] with [fill]. */
-		eatStr: function (str, side, bite_size, fill) {
-			var length = str.length,
-				key = utils.eatStr.generateKey.apply(null, arguments),
-				half_length,
-				half_bite_size;
+            /* Display the biggest bite. */
+            this.html(max_bite);
 
-			/* If the result is already in the cache, return it. */
-			if (utils.eatStr.cache[key]) {
-				return utils.eatStr.cache[key];
-			}
-			
-			/* Common error handling. */
-			if ((typeof str !== 'string') || (length === 0)) {
-				$.error('Invalid source string "' + str + '".');
-			}
-			if ((bite_size < 0) || (bite_size > length)) {
-				$.error('Invalid bite size "' + bite_size + '".');
-			}
-			else if (bite_size === 0) {
-				/* No bite should show no truncation. */
-				return str;
-			}
-			if (typeof (fill + '') !== 'string') {
-				$.error('Fill unable to be converted to a string.');
-			}
+            if (settings.tooltip) {
+                this.attr('title', text);
+            }
+        }
+        else if (!isNaN(width)) {
+            bite_size = length - width;
 
-			/* Compute the result, store it in the cache, and return it. */
-			switch (side) {
-				case SIDES.right:
-					/* str... */
-					return utils.eatStr.cache[key] =
-							$.trim(str.substr(0, length - bite_size)) + fill;
-					
-				case SIDES.left:
-					/* ...str */
-					return utils.eatStr.cache[key] =
-							fill + $.trim(str.substr(bite_size));
-					
-				case SIDES.center:
-					/* Bit-shift to the right by one === Math.floor(x / 2) */
-					half_length = length >> 1; // halve the length
-					half_bite_size = bite_size >> 1; // halve the bite_size
+            bite = utils.eatStr(str, side, bite_size, fill);
 
-					/* st...r */
-					return utils.eatStr.cache[key] =
-							$.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
-							fill +
-							$.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
-					
-				default:
-					$.error('Invalid side "' + side + '".');
-			}
-		},
-		
-		getLineHeight: function (elem) {
-				var floats = $(elem).css('float');
-				if (floats !== 'none') {
-					$(elem).css('float', 'none');
-				}
-				var pos = $(elem).css('position');
-				if (pos === 'absolute') {
-					$(elem).css('position', 'static');
-				}
-	
-				var html = $(elem).html(),
-				wrapper_id = 'line-height-test',
-				line_height;
-	
-				/* Set the content to a small single character and wrap. */
-				$(elem).html('i').wrap('<div id="' + wrapper_id + '" />');
-	
-				/* Calculate the line height by measuring the wrapper.*/
-				line_height = $('#' + wrapper_id).innerHeight();
-	
-				/* Remove the wrapper and reset the content. */
-				$(elem).html(html).css({ 'float': floats, 'position': pos }).unwrap();
-	
-				return line_height;
-			}
-	};
+            this.html(bite);
 
-	utils.eatStr.cache = {};
-	utils.eatStr.generateKey = function () {
-		return Array.prototype.join.call(arguments, '');
-	};
-	
-	$.fn.trunk8 = function (method) {
-		if (methods[method]) {
-			return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
-		}
-		else if (typeof method === 'object' || !method) {
-			return methods.init.apply(this, arguments);
-		}
-		else {
-			$.error('Method ' + method + ' does not exist on jQuery.trunk8');
-		}
-	};
-	
-	/* Default trunk8 settings. */
-	$.fn.trunk8.defaults = {
-		fill: '&hellip;',
-		lines: 1,
-		side: SIDES.right,
-		tooltip: true,
-		width: WIDTH.auto,
-		parseHTML: false,
-		onTruncate: function () {}
-	};
+            if (settings.tooltip) {
+                this.attr('title', str);
+            }
+        }
+        else {
+            $.error('Invalid width "' + width + '".');
+            return;
+        }
+
+        // If we use pre-render element, replace it's content with our truncated element and show it.
+        // This prevents the 'jumping' of the page.
+        if (settings.usePreRenderElement) {
+            var truncatedElement = this.clone(true);
+
+            truncatedElement
+                .removeClass('hidden');
+
+            settings.preRenderElement.replaceWith(truncatedElement);
+        }
+
+        settings.onTruncate();
+    }
+
+    methods = {
+        init: function (options) {
+            return this.each(function () {
+                var $this = $(this),
+                    data = $this.data('trunk8');
+
+                // Copy html from preRenderElement
+                if (options !== undefined && options.usePreRenderElement) {
+                    $this.html(options.preRenderElement.html());
+                }
+
+                if (!data) {
+                    $this.data('trunk8', (data = new trunk8(this)));
+                }
+
+                data.updateSettings(options);
+
+                truncate.call($this);
+            });
+        },
+
+        /** Updates the text value of the elements while maintaining truncation. */
+        update: function (new_string) {
+            return this.each(function () {
+                var $this = $(this);
+
+                /* Update text. */
+                if (new_string) {
+                    $this.data('trunk8').original_text = new_string;
+                }
+
+                /* Truncate accordingly. */
+                truncate.call($this);
+            });
+        },
+
+        revert: function () {
+            return this.each(function () {
+                /* Get original text. */
+                var text = $(this).data('trunk8').original_text;
+
+                /* Revert element to original text. */
+                $(this).html(text);
+            });
+        },
+
+        /** Returns this instance's settings object. NOT CHAINABLE. */
+        getSettings: function () {
+            return $(this.get(0)).data('trunk8').settings;
+        }
+    };
+
+    utils = {
+        /** Replaces [bite_size] [side]-most chars in [str] with [fill]. */
+        eatStr: function (str, side, bite_size, fill) {
+            var length = str.length,
+                key = utils.eatStr.generateKey.apply(null, arguments),
+                half_length,
+                half_bite_size;
+
+            /* If the result is already in the cache, return it. */
+            if (utils.eatStr.cache[key]) {
+                return utils.eatStr.cache[key];
+            }
+
+            /* Common error handling. */
+            if ((typeof str !== 'string') || (length === 0)) {
+                $.error('Invalid source string "' + str + '".');
+            }
+            if ((bite_size < 0) || (bite_size > length)) {
+                $.error('Invalid bite size "' + bite_size + '".');
+            }
+            else if (bite_size === 0) {
+                /* No bite should show no truncation. */
+                return str;
+            }
+            if (typeof (fill + '') !== 'string') {
+                $.error('Fill unable to be converted to a string.');
+            }
+
+            /* Compute the result, store it in the cache, and return it. */
+            switch (side) {
+                case SIDES.right:
+                    /* str... */
+                    return utils.eatStr.cache[key] =
+                        $.trim(str.substr(0, length - bite_size)) + fill;
+
+                case SIDES.left:
+                    /* ...str */
+                    return utils.eatStr.cache[key] =
+                        fill + $.trim(str.substr(bite_size));
+
+                case SIDES.center:
+                    /* Bit-shift to the right by one === Math.floor(x / 2) */
+                    half_length = length >> 1; // halve the length
+                    half_bite_size = bite_size >> 1; // halve the bite_size
+
+                    /* st...r */
+                    return utils.eatStr.cache[key] =
+                        $.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
+                        fill +
+                        $.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
+
+                default:
+                    $.error('Invalid side "' + side + '".');
+            }
+        },
+
+        getLineHeight: function (elem) {
+            var html = $(elem).html();
+
+            /* Set the content to a small single character and wrap. */
+            $(elem).html('i');
+
+            /* Calculate the line height by measuring the wrapper.*/
+            var line_height = utils.getHeight($(elem));
+
+            /* Reset the content. */
+            $(elem).html(html);
+
+            return line_height;
+        },
+
+        getHeight: function(elem) {
+            var height = elem.height();
+            if (height > 0) {
+                return height;
+            }
+            else {
+                // get all hidden parents
+                var tmp = [];
+                var $hidden = elem.parents().addBack().filter(':hidden');
+                var style = 'visibility: hidden !important; display: block !important; ';
+
+                // save the origin style props
+                // set the hidden el css to be got the actual value later
+                $hidden.each( function (){
+                    // Save original style. If no style was set, attr() returns undefined
+                    var elementStyle = elem.attr('style');
+
+                    tmp.push(elementStyle);
+                    // Retain as much of the original style as possible, if there is one
+                    elem.attr('style', elementStyle ? elementStyle + ';' + style : style );
+                });
+
+                height = elem.height();
+
+                $hidden.each( function ( i ){
+                    var _tmp = tmp[i];
+
+                    if(_tmp === undefined) {
+                        elem.removeAttr('style');
+                    }
+                    else {
+                        elem.attr('style', _tmp);
+                    }
+                });
+
+                return height;
+            }
+        }
+    };
+
+    utils.eatStr.cache = {};
+    utils.eatStr.generateKey = function () {
+        return Array.prototype.join.call(arguments, '');
+    };
+
+    $.fn.trunk8 = function (method) {
+        if (methods[method]) {
+            return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
+        }
+        else if (typeof method === 'object' || !method) {
+            return methods.init.apply(this, arguments);
+        }
+        else {
+            $.error('Method ' + method + ' does not exist on jQuery.trunk8');
+        }
+    };
+
+    /* Default trunk8 settings. */
+    $.fn.trunk8.defaults = {
+        fill: '&hellip;',
+        lines: 1,
+        side: SIDES.right,
+        tooltip: true,
+        width: WIDTH.auto,
+        parseHTML: false,
+        usePreRenderElement: false,
+        preRenderElement: undefined,
+        onTruncate: function () {}
+    };
 })(jQuery);

--- a/trunk8.js
+++ b/trunk8.js
@@ -1,431 +1,431 @@
 /**!
- * trunk8 v1.3.3
- * https://github.com/rviscomi/trunk8
- *
- * Copyright 2012 Rick Viscomi
- * Released under the MIT License.
- *
- * Date: September 26, 2012
- */
+* trunk8 v1.3.3
+* https://github.com/rviscomi/trunk8
+*
+* Copyright 2012 Rick Viscomi
+* Released under the MIT License.
+*
+* Date: September 26, 2012
+*/
 
 (function ($) {
-    var methods,
-        utils,
-        SIDES = {
-            /* cen...ter */
-            center: 'center',
-            /* ...left */
-            left: 'left',
-            /* right... */
-            right: 'right'
-        },
-        WIDTH = {
-            auto: 'auto'
-        };
-
-    function trunk8(element) {
-        this.$element = $(element);
-        this.original_text = this.$element.html().trim();
-        this.settings = $.extend({}, $.fn.trunk8.defaults);
-    }
-
-    trunk8.prototype.updateSettings = function (options) {
-        this.settings = $.extend(this.settings, options);
-    };
-
-    function stripHTML(html) {
-        var tmp = document.createElement("DIV");
-        tmp.innerHTML = html;
-
-        if (typeof tmp.textContent != 'undefined') {
-            return tmp.textContent;
-        }
-
-        return tmp.innerText
-    }
-
-    function getHtmlArr(str) {
-        /* Builds an array of strings and designated */
-        /* HTML tags around them. */
-        if (stripHTML(str) === str) {
-            return str.split(/\s/g);
-        }
-        var allResults = [],
-            reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>)*)<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
-            outArr = reg.exec(str),
-            lastI,
-            ind;
-        while (outArr && lastI !== reg.lastIndex) {
-            lastI = reg.lastIndex;
-            if (outArr[5]) {
-                allResults.push(outArr[5]);
-            } else if (outArr[1]) {
-                allResults.push({
-                    tag: outArr[1],
-                    attribs: outArr[2],
-                    content: outArr[3],
-                    after: outArr[4]
-                });
-            }
-            outArr = reg.exec(str);
-        }
-        for (ind = 0; ind < allResults.length; ind++) {
-            if (typeof allResults[ind] !== 'string' &&
-                allResults[ind].content) {
-                allResults[ind].content = getHtmlArr(allResults[ind].content);
-            }
-        }
-        return allResults;
-    }
-
-    function rebuildHtmlFromBite(bite, htmlObject, fill) {
-        // Take the processed bite after binary-search
-        // truncated and re-build the original HTML
-        // tags around the processed string.
-        bite = bite.replace(fill, '');
-
-        var biteHelper = function(contentArr, tagInfo) {
-                var retStr = '',
-                    content,
-                    biteContent,
-                    biteLength,
-                    nextWord,
-                    i;
-                for (i = 0; i < contentArr.length; i++) {
-                    content = contentArr[i];
-                    biteLength = $.trim(bite).split(' ').length;
-                    if ($.trim(bite).length) {
-                        if (typeof content === 'string') {
-                            if (!/<br\s*\/?>/.test(content)) {
-                                if (biteLength === 1 && $.trim(bite).length <= content.length) {
-                                    content = bite;
-                                    // We want the fill to go inside of the last HTML
-                                    // element if the element is a container.
-                                    if (tagInfo === 'p' || tagInfo === 'div') {
-                                        content += fill;
-                                    }
-                                    bite = '';
-                                } else {
-                                    bite = bite.replace(content, '');
-                                }
-                            }
-                            retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
-                        } else {
-                            biteContent = biteHelper(content.content, content.tag);
-                            if (content.after) bite = bite.replace(content.after, '');
-                            if (biteContent) {
-                                if (!content.after) content.after = ' ';
-                                retStr += '<'+content.tag+content.attribs+'>'+biteContent+'</'+content.tag+'>' + content.after;
-                            }
-                        }
-                    }
-                }
-                return retStr;
-            },
-            htmlResults = biteHelper(htmlObject);
-
-        // Add fill if doesn't exist. This will place it outside the HTML elements.
-        if (htmlResults.slice(htmlResults.length - fill.length) === fill) {
-            htmlResults += fill;
-        }
-
-        return htmlResults;
-    }
-
-    function truncate() {
-        var data = this.data('trunk8'),
-            settings = data.settings,
-            width = settings.width,
-            side = settings.side,
-            fill = settings.fill,
-            parseHTML = settings.parseHTML,
-            line_height = utils.getLineHeight(this) * settings.lines,
-            str = data.original_text,
-            length = str.length,
-            max_bite = '',
-            lower, upper,
-            bite_size,
-            bite,
-            text,
-            htmlObject;
-
-        /* Reset the field to the original string. */
-        this.html(str);
-        text = this.text();
-
-        /* If string has HTML and parse HTML is set, build */
-        /* the data struct to house the tags */
-        if (parseHTML && stripHTML(str) !== str) {
-            htmlObject = getHtmlArr(str);
-            str = stripHTML(str);
-            length = str.length;
-        }
-
-        if (width === WIDTH.auto) {
-            /* Assuming there is no "overflow: hidden". */
-            if (utils.getHeight(this) <= line_height) {
-                /* Text is already at the optimal trunkage. */
-                return;
-            }
-
-            /* Binary search technique for finding the optimal trunkage. */
-            /* Find the maximum bite without overflowing. */
-            lower = 0;
-            upper = length - 1;
-
-            while (lower <= upper) {
-                bite_size = lower + ((upper - lower) >> 1);
-
-                bite = utils.eatStr(str, side, length - bite_size, fill);
-
-                if (parseHTML && htmlObject) {
-                    bite = rebuildHtmlFromBite(bite, htmlObject, fill);
-                }
-
-                this.html(bite);
-
-                /* Check for overflow. */
-                if (utils.getHeight(this) > line_height) {
-                    upper = bite_size - 1;
-                }
-                else {
-                    lower = bite_size + 1;
-
-                    /* Save the bigger bite. */
-                    max_bite = (max_bite.length > bite.length) ? max_bite : bite;
-                }
-            }
-
-            /* Reset the content to eliminate possible existing scroll bars. */
-            this.html('');
-
-            /* Display the biggest bite. */
-            this.html(max_bite);
-
-            if (settings.tooltip) {
-                this.attr('title', text);
-            }
-        }
-        else if (!isNaN(width)) {
-            bite_size = length - width;
-
-            bite = utils.eatStr(str, side, bite_size, fill);
-
-            this.html(bite);
-
-            if (settings.tooltip) {
-                this.attr('title', str);
-            }
-        }
-        else {
-            $.error('Invalid width "' + width + '".');
-            return;
-        }
-
-        // If we use pre-render element, replace it's content with our truncated element and show it.
-        // This prevents the 'jumping' of the page.
-        if (settings.usePreRenderElement) {
-            var truncatedElement = this.clone(true);
-
-            truncatedElement
-                .removeClass('hidden');
-
-            settings.preRenderElement.replaceWith(truncatedElement);
-        }
-
-        settings.onTruncate();
-    }
-
-    methods = {
-        init: function (options) {
-            return this.each(function () {
-                var $this = $(this),
-                    data = $this.data('trunk8');
-
-                // Copy html from preRenderElement
-                if (options !== undefined && options.usePreRenderElement) {
-                    $this.html(options.preRenderElement.html());
-                }
-
-                if (!data) {
-                    $this.data('trunk8', (data = new trunk8(this)));
-                }
-
-                data.updateSettings(options);
-
-                truncate.call($this);
-            });
-        },
-
-        /** Updates the text value of the elements while maintaining truncation. */
-        update: function (new_string) {
-            return this.each(function () {
-                var $this = $(this);
-
-                /* Update text. */
-                if (new_string) {
-                    $this.data('trunk8').original_text = new_string;
-                }
-
-                /* Truncate accordingly. */
-                truncate.call($this);
-            });
-        },
-
-        revert: function () {
-            return this.each(function () {
-                /* Get original text. */
-                var text = $(this).data('trunk8').original_text;
-
-                /* Revert element to original text. */
-                $(this).html(text);
-            });
-        },
-
-        /** Returns this instance's settings object. NOT CHAINABLE. */
-        getSettings: function () {
-            return $(this.get(0)).data('trunk8').settings;
-        }
-    };
-
-    utils = {
-        /** Replaces [bite_size] [side]-most chars in [str] with [fill]. */
-        eatStr: function (str, side, bite_size, fill) {
-            var length = str.length,
-                key = utils.eatStr.generateKey.apply(null, arguments),
-                half_length,
-                half_bite_size;
-
-            /* If the result is already in the cache, return it. */
-            if (utils.eatStr.cache[key]) {
-                return utils.eatStr.cache[key];
-            }
-
-            /* Common error handling. */
-            if ((typeof str !== 'string') || (length === 0)) {
-                $.error('Invalid source string "' + str + '".');
-            }
-            if ((bite_size < 0) || (bite_size > length)) {
-                $.error('Invalid bite size "' + bite_size + '".');
-            }
-            else if (bite_size === 0) {
-                /* No bite should show no truncation. */
-                return str;
-            }
-            if (typeof (fill + '') !== 'string') {
-                $.error('Fill unable to be converted to a string.');
-            }
-
-            /* Compute the result, store it in the cache, and return it. */
-            switch (side) {
-                case SIDES.right:
-                    /* str... */
-                    return utils.eatStr.cache[key] =
-                        $.trim(str.substr(0, length - bite_size)) + fill;
-
-                case SIDES.left:
-                    /* ...str */
-                    return utils.eatStr.cache[key] =
-                        fill + $.trim(str.substr(bite_size));
-
-                case SIDES.center:
-                    /* Bit-shift to the right by one === Math.floor(x / 2) */
-                    half_length = length >> 1; // halve the length
-                    half_bite_size = bite_size >> 1; // halve the bite_size
-
-                    /* st...r */
-                    return utils.eatStr.cache[key] =
-                        $.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
-                        fill +
-                        $.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
-
-                default:
-                    $.error('Invalid side "' + side + '".');
-            }
-        },
-
-        getLineHeight: function (elem) {
-            var html = $(elem).html();
-
-            /* Set the content to a small single character and wrap. */
-            $(elem).html('i');
-
-            /* Calculate the line height by measuring the wrapper.*/
-            var line_height = utils.getHeight($(elem));
-
-            /* Reset the content. */
-            $(elem).html(html);
-
-            return line_height;
-        },
-
-        getHeight: function(elem) {
-            var height = elem.height();
-            if (height > 0) {
-                return height;
-            }
-            else {
-                // get all hidden parents
-                var tmp = [];
-                var $hidden = elem.parents().addBack().filter(':hidden');
-                var style = 'visibility: hidden !important; display: block !important; ';
-
-                // save the origin style props
-                // set the hidden el css to be got the actual value later
-                $hidden.each( function (){
-                    // Save original style. If no style was set, attr() returns undefined
-                    var elementStyle = elem.attr('style');
-
-                    tmp.push(elementStyle);
-                    // Retain as much of the original style as possible, if there is one
-                    elem.attr('style', elementStyle ? elementStyle + ';' + style : style );
-                });
-
-                height = elem.height();
-
-                $hidden.each( function ( i ){
-                    var _tmp = tmp[i];
-
-                    if(_tmp === undefined) {
-                        elem.removeAttr('style');
-                    }
-                    else {
-                        elem.attr('style', _tmp);
-                    }
-                });
-
-                return height;
-            }
-        }
-    };
-
-    utils.eatStr.cache = {};
-    utils.eatStr.generateKey = function () {
-        return Array.prototype.join.call(arguments, '');
-    };
-
-    $.fn.trunk8 = function (method) {
-        if (methods[method]) {
-            return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
-        }
-        else if (typeof method === 'object' || !method) {
-            return methods.init.apply(this, arguments);
-        }
-        else {
-            $.error('Method ' + method + ' does not exist on jQuery.trunk8');
-        }
-    };
-
-    /* Default trunk8 settings. */
-    $.fn.trunk8.defaults = {
-        fill: '&hellip;',
-        lines: 1,
-        side: SIDES.right,
-        tooltip: true,
-        width: WIDTH.auto,
-        parseHTML: false,
-        usePreRenderElement: false,
-        preRenderElement: undefined,
-        onTruncate: function () {}
-    };
+	var methods,
+	utils,
+	SIDES = {
+		/* cen...ter */
+		center: 'center',
+		/* ...left */
+		left: 'left',
+		/* right... */
+		right: 'right'
+	},
+	WIDTH = {
+		auto: 'auto'
+	};
+
+	function trunk8(element) {
+		this.$element = $(element);
+		this.original_text = this.$element.html().trim();
+		this.settings = $.extend({}, $.fn.trunk8.defaults);
+	}
+
+	trunk8.prototype.updateSettings = function (options) {
+		this.settings = $.extend(this.settings, options);
+	};
+
+	function stripHTML(html) {
+		var tmp = document.createElement("DIV");
+		tmp.innerHTML = html;
+
+		if (typeof tmp.textContent != 'undefined') {
+			return tmp.textContent;
+		}
+
+		return tmp.innerText
+	}
+
+	function getHtmlArr(str) {
+		/* Builds an array of strings and designated */
+		/* HTML tags around them. */
+		if (stripHTML(str) === str) {
+			return str.split(/\s/g);
+		}
+		var allResults = [],
+		reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>)*)<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
+		outArr = reg.exec(str),
+		lastI,
+		ind;
+		while (outArr && lastI !== reg.lastIndex) {
+			lastI = reg.lastIndex;
+			if (outArr[5]) {
+				allResults.push(outArr[5]);
+			} else if (outArr[1]) {
+				allResults.push({
+					tag: outArr[1],
+					attribs: outArr[2],
+					content: outArr[3],
+					after: outArr[4]
+				});
+			}
+			outArr = reg.exec(str);
+		}
+		for (ind = 0; ind < allResults.length; ind++) {
+			if (typeof allResults[ind] !== 'string' &&
+			allResults[ind].content) {
+				allResults[ind].content = getHtmlArr(allResults[ind].content);
+			}
+		}
+		return allResults;
+	}
+
+	function rebuildHtmlFromBite(bite, htmlObject, fill) {
+		// Take the processed bite after binary-search
+		// truncated and re-build the original HTML
+		// tags around the processed string.
+		bite = bite.replace(fill, '');
+
+		var biteHelper = function(contentArr, tagInfo) {
+			var retStr = '',
+			content,
+			biteContent,
+			biteLength,
+			nextWord,
+			i;
+			for (i = 0; i < contentArr.length; i++) {
+				content = contentArr[i];
+				biteLength = $.trim(bite).split(' ').length;
+				if ($.trim(bite).length) {
+					if (typeof content === 'string') {
+						if (!/<br\s*\/?>/.test(content)) {
+							if (biteLength === 1 && $.trim(bite).length <= content.length) {
+								content = bite;
+								// We want the fill to go inside of the last HTML
+								// element if the element is a container.
+								if (tagInfo === 'p' || tagInfo === 'div') {
+									content += fill;
+								}
+								bite = '';
+							} else {
+								bite = bite.replace(content, '');
+							}
+						}
+						retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
+					} else {
+						biteContent = biteHelper(content.content, content.tag);
+						if (content.after) bite = bite.replace(content.after, '');
+						if (biteContent) {
+							if (!content.after) content.after = ' ';
+							retStr += '<'+content.tag+content.attribs+'>'+biteContent+'</'+content.tag+'>' + content.after;
+						}
+					}
+				}
+			}
+			return retStr;
+		},
+		htmlResults = biteHelper(htmlObject);
+
+		// Add fill if doesn't exist. This will place it outside the HTML elements.
+		if (htmlResults.slice(htmlResults.length - fill.length) === fill) {
+			htmlResults += fill;
+		}
+
+		return htmlResults;
+	}
+
+	function truncate() {
+		var data = this.data('trunk8'),
+		settings = data.settings,
+		width = settings.width,
+		side = settings.side,
+		fill = settings.fill,
+		parseHTML = settings.parseHTML,
+		line_height = utils.getLineHeight(this) * settings.lines,
+		str = data.original_text,
+		length = str.length,
+		max_bite = '',
+		lower, upper,
+		bite_size,
+		bite,
+		text,
+		htmlObject;
+
+		/* Reset the field to the original string. */
+		this.html(str);
+		text = this.text();
+
+		/* If string has HTML and parse HTML is set, build */
+		/* the data struct to house the tags */
+		if (parseHTML && stripHTML(str) !== str) {
+			htmlObject = getHtmlArr(str);
+			str = stripHTML(str);
+			length = str.length;
+		}
+
+		if (width === WIDTH.auto) {
+			/* Assuming there is no "overflow: hidden". */
+			if (utils.getHeight(this) <= line_height) {
+				/* Text is already at the optimal trunkage. */
+				return;
+			}
+
+			/* Binary search technique for finding the optimal trunkage. */
+			/* Find the maximum bite without overflowing. */
+			lower = 0;
+			upper = length - 1;
+
+			while (lower <= upper) {
+				bite_size = lower + ((upper - lower) >> 1);
+
+				bite = utils.eatStr(str, side, length - bite_size, fill);
+
+				if (parseHTML && htmlObject) {
+					bite = rebuildHtmlFromBite(bite, htmlObject, fill);
+				}
+
+				this.html(bite);
+
+				/* Check for overflow. */
+				if (utils.getHeight(this) > line_height) {
+					upper = bite_size - 1;
+				}
+				else {
+					lower = bite_size + 1;
+
+					/* Save the bigger bite. */
+					max_bite = (max_bite.length > bite.length) ? max_bite : bite;
+				}
+			}
+
+			/* Reset the content to eliminate possible existing scroll bars. */
+			this.html('');
+
+			/* Display the biggest bite. */
+			this.html(max_bite);
+
+			if (settings.tooltip) {
+				this.attr('title', text);
+			}
+		}
+		else if (!isNaN(width)) {
+			bite_size = length - width;
+
+			bite = utils.eatStr(str, side, bite_size, fill);
+
+			this.html(bite);
+
+			if (settings.tooltip) {
+				this.attr('title', str);
+			}
+		}
+		else {
+			$.error('Invalid width "' + width + '".');
+			return;
+		}
+
+		// If we use pre-render element, replace it's content with our truncated element and show it.
+		// This prevents the 'jumping' of the page.
+		if (settings.usePreRenderElement) {
+			var truncatedElement = this.clone(true);
+
+			truncatedElement
+			.removeClass('hidden');
+
+			settings.preRenderElement.replaceWith(truncatedElement);
+		}
+
+		settings.onTruncate();
+	}
+
+	methods = {
+		init: function (options) {
+			return this.each(function () {
+				var $this = $(this),
+				data = $this.data('trunk8');
+
+				// Copy html from preRenderElement
+				if (options !== undefined && options.usePreRenderElement) {
+					$this.html(options.preRenderElement.html());
+				}
+
+				if (!data) {
+					$this.data('trunk8', (data = new trunk8(this)));
+				}
+
+				data.updateSettings(options);
+
+				truncate.call($this);
+			});
+		},
+
+		/** Updates the text value of the elements while maintaining truncation. */
+		update: function (new_string) {
+			return this.each(function () {
+				var $this = $(this);
+
+				/* Update text. */
+				if (new_string) {
+					$this.data('trunk8').original_text = new_string;
+				}
+
+				/* Truncate accordingly. */
+				truncate.call($this);
+			});
+		},
+
+		revert: function () {
+			return this.each(function () {
+				/* Get original text. */
+				var text = $(this).data('trunk8').original_text;
+
+				/* Revert element to original text. */
+				$(this).html(text);
+			});
+		},
+
+		/** Returns this instance's settings object. NOT CHAINABLE. */
+		getSettings: function () {
+			return $(this.get(0)).data('trunk8').settings;
+		}
+	};
+
+	utils = {
+		/** Replaces [bite_size] [side]-most chars in [str] with [fill]. */
+		eatStr: function (str, side, bite_size, fill) {
+			var length = str.length,
+			key = utils.eatStr.generateKey.apply(null, arguments),
+			half_length,
+			half_bite_size;
+
+			/* If the result is already in the cache, return it. */
+			if (utils.eatStr.cache[key]) {
+				return utils.eatStr.cache[key];
+			}
+
+			/* Common error handling. */
+			if ((typeof str !== 'string') || (length === 0)) {
+				$.error('Invalid source string "' + str + '".');
+			}
+			if ((bite_size < 0) || (bite_size > length)) {
+				$.error('Invalid bite size "' + bite_size + '".');
+			}
+			else if (bite_size === 0) {
+				/* No bite should show no truncation. */
+				return str;
+			}
+			if (typeof (fill + '') !== 'string') {
+				$.error('Fill unable to be converted to a string.');
+			}
+
+			/* Compute the result, store it in the cache, and return it. */
+			switch (side) {
+				case SIDES.right:
+				/* str... */
+				return utils.eatStr.cache[key] =
+				$.trim(str.substr(0, length - bite_size)) + fill;
+
+				case SIDES.left:
+				/* ...str */
+				return utils.eatStr.cache[key] =
+				fill + $.trim(str.substr(bite_size));
+
+				case SIDES.center:
+				/* Bit-shift to the right by one === Math.floor(x / 2) */
+				half_length = length >> 1; // halve the length
+				half_bite_size = bite_size >> 1; // halve the bite_size
+
+				/* st...r */
+				return utils.eatStr.cache[key] =
+				$.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
+				fill +
+				$.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
+
+				default:
+				$.error('Invalid side "' + side + '".');
+			}
+		},
+
+		getLineHeight: function (elem) {
+			var html = $(elem).html();
+
+			/* Set the content to a small single character and wrap. */
+			$(elem).html('i');
+
+			/* Calculate the line height by measuring the wrapper.*/
+			var line_height = utils.getHeight($(elem));
+
+			/* Reset the content. */
+			$(elem).html(html);
+
+			return line_height;
+		},
+
+		getHeight: function(elem) {
+			var height = elem.height();
+			if (height > 0) {
+				return height;
+			}
+			else {
+				// get all hidden parents
+				var tmp = [];
+				var $hidden = elem.parents().addBack().filter(':hidden');
+				var style = 'visibility: hidden !important; display: block !important; ';
+
+				// save the origin style props
+				// set the hidden el css to be got the actual value later
+				$hidden.each( function (){
+					// Save original style. If no style was set, attr() returns undefined
+					var elementStyle = elem.attr('style');
+
+					tmp.push(elementStyle);
+					// Retain as much of the original style as possible, if there is one
+					elem.attr('style', elementStyle ? elementStyle + ';' + style : style );
+				});
+
+				height = elem.height();
+
+				$hidden.each( function ( i ){
+					var _tmp = tmp[i];
+
+					if(_tmp === undefined) {
+						elem.removeAttr('style');
+					}
+					else {
+						elem.attr('style', _tmp);
+					}
+				});
+
+				return height;
+			}
+		}
+	};
+
+	utils.eatStr.cache = {};
+	utils.eatStr.generateKey = function () {
+		return Array.prototype.join.call(arguments, '');
+	};
+
+	$.fn.trunk8 = function (method) {
+		if (methods[method]) {
+			return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
+		}
+		else if (typeof method === 'object' || !method) {
+			return methods.init.apply(this, arguments);
+		}
+		else {
+			$.error('Method ' + method + ' does not exist on jQuery.trunk8');
+		}
+	};
+
+	/* Default trunk8 settings. */
+	$.fn.trunk8.defaults = {
+		fill: '&hellip;',
+		lines: 1,
+		side: SIDES.right,
+		tooltip: true,
+		width: WIDTH.auto,
+		parseHTML: false,
+		usePreRenderElement: false,
+		preRenderElement: undefined,
+		onTruncate: function () {}
+	};
 })(jQuery);

--- a/trunk8.js
+++ b/trunk8.js
@@ -1,31 +1,31 @@
 /**!
-* trunk8 v1.3.3
-* https://github.com/rviscomi/trunk8
-*
-* Copyright 2012 Rick Viscomi
-* Released under the MIT License.
-*
-* Date: September 26, 2012
-*/
+ * trunk8 v1.3.3
+ * https://github.com/rviscomi/trunk8
+ *
+ * Copyright 2012 Rick Viscomi
+ * Released under the MIT License.
+ *
+ * Date: September 26, 2012
+ */
 
 (function ($) {
 	var methods,
-	utils,
-	SIDES = {
-		/* cen...ter */
-		center: 'center',
-		/* ...left */
-		left: 'left',
-		/* right... */
-		right: 'right'
-	},
-	WIDTH = {
-		auto: 'auto'
+		utils,
+		SIDES = {
+			/* cen...ter */
+			center: 'center',
+			/* ...left */
+			left: 'left',
+			/* right... */
+			right: 'right'
+		},
+		WIDTH = {
+			auto: 'auto'
 	};
 
 	function trunk8(element) {
 		this.$element = $(element);
-		this.original_text = this.$element.html().trim();
+		this.original_text = $.trim(this.$element.html();
 		this.settings = $.extend({}, $.fn.trunk8.defaults);
 	}
 
@@ -51,10 +51,10 @@
 			return str.split(/\s/g);
 		}
 		var allResults = [],
-		reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>)*)<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
-		outArr = reg.exec(str),
-		lastI,
-		ind;
+			reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>)*)<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
+			outArr = reg.exec(str),
+			lastI,
+			ind;
 		while (outArr && lastI !== reg.lastIndex) {
 			lastI = reg.lastIndex;
 			if (outArr[5]) {
@@ -71,7 +71,7 @@
 		}
 		for (ind = 0; ind < allResults.length; ind++) {
 			if (typeof allResults[ind] !== 'string' &&
-			allResults[ind].content) {
+				allResults[ind].content) {
 				allResults[ind].content = getHtmlArr(allResults[ind].content);
 			}
 		}
@@ -85,44 +85,44 @@
 		bite = bite.replace(fill, '');
 
 		var biteHelper = function(contentArr, tagInfo) {
-			var retStr = '',
-			content,
-			biteContent,
-			biteLength,
-			nextWord,
-			i;
-			for (i = 0; i < contentArr.length; i++) {
-				content = contentArr[i];
-				biteLength = $.trim(bite).split(' ').length;
-				if ($.trim(bite).length) {
-					if (typeof content === 'string') {
-						if (!/<br\s*\/?>/.test(content)) {
-							if (biteLength === 1 && $.trim(bite).length <= content.length) {
-								content = bite;
-								// We want the fill to go inside of the last HTML
-								// element if the element is a container.
-								if (tagInfo === 'p' || tagInfo === 'div') {
-									content += fill;
-								}
-								bite = '';
-							} else {
-								bite = bite.replace(content, '');
+				var retStr = '',
+					content,
+					biteContent,
+					biteLength,
+					nextWord,
+					i;
+				for (i = 0; i < contentArr.length; i++) {
+					content = contentArr[i];
+					biteLength = $.trim(bite).split(' ').length;
+					if ($.trim(bite).length) {
+						if (typeof content === 'string') {
+							if (!/<br\s*\/?>/.test(content)) {
+								if (biteLength === 1 && $.trim(bite).length <= content.length) {
+									content = bite;
+									// We want the fill to go inside of the last HTML
+									// element if the element is a container.
+									if (tagInfo === 'p' || tagInfo === 'div') {
+										content += fill;
+									}
+									bite = '';
+								} else {
+									bite = bite.replace(content, '');
 							}
 						}
-						retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
-					} else {
-						biteContent = biteHelper(content.content, content.tag);
-						if (content.after) bite = bite.replace(content.after, '');
-						if (biteContent) {
-							if (!content.after) content.after = ' ';
-							retStr += '<'+content.tag+content.attribs+'>'+biteContent+'</'+content.tag+'>' + content.after;
+							retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
+						} else {
+							biteContent = biteHelper(content.content, content.tag);
+							if (content.after) bite = bite.replace(content.after, '');
+							if (biteContent) {
+								if (!content.after) content.after = ' ';
+								retStr += '<'+content.tag+content.attribs+'>'+biteContent+'</'+content.tag+'>' + content.after;
+							}
 						}
 					}
 				}
-			}
-			return retStr;
-		},
-		htmlResults = biteHelper(htmlObject);
+				return retStr;
+			},
+			htmlResults = biteHelper(htmlObject);
 
 		// Add fill if doesn't exist. This will place it outside the HTML elements.
 		if (htmlResults.slice(htmlResults.length - fill.length) === fill) {
@@ -134,20 +134,20 @@
 
 	function truncate() {
 		var data = this.data('trunk8'),
-		settings = data.settings,
-		width = settings.width,
-		side = settings.side,
-		fill = settings.fill,
-		parseHTML = settings.parseHTML,
-		line_height = utils.getLineHeight(this) * settings.lines,
-		str = data.original_text,
-		length = str.length,
-		max_bite = '',
-		lower, upper,
-		bite_size,
-		bite,
-		text,
-		htmlObject;
+			settings = data.settings,
+			width = settings.width,
+			side = settings.side,
+			fill = settings.fill,
+			parseHTML = settings.parseHTML,
+			line_height = utils.getLineHeight(this) * settings.lines,
+			str = data.original_text,
+			length = str.length,
+			max_bite = '',
+			lower, upper,
+			bite_size,
+			bite,
+			text,
+			htmlObject;
 
 		/* Reset the field to the original string. */
 		this.html(str);
@@ -240,7 +240,7 @@
 		init: function (options) {
 			return this.each(function () {
 				var $this = $(this),
-				data = $this.data('trunk8');
+					data = $this.data('trunk8');
 
 				// Copy html from preRenderElement
 				if (options !== undefined && options.usePreRenderElement) {
@@ -292,9 +292,9 @@
 		/** Replaces [bite_size] [side]-most chars in [str] with [fill]. */
 		eatStr: function (str, side, bite_size, fill) {
 			var length = str.length,
-			key = utils.eatStr.generateKey.apply(null, arguments),
-			half_length,
-			half_bite_size;
+				key = utils.eatStr.generateKey.apply(null, arguments),
+				half_length,
+				half_bite_size;
 
 			/* If the result is already in the cache, return it. */
 			if (utils.eatStr.cache[key]) {
@@ -319,44 +319,44 @@
 			/* Compute the result, store it in the cache, and return it. */
 			switch (side) {
 				case SIDES.right:
-				/* str... */
-				return utils.eatStr.cache[key] =
-				$.trim(str.substr(0, length - bite_size)) + fill;
+					/* str... */
+					return utils.eatStr.cache[key] =
+							$.trim(str.substr(0, length - bite_size)) + fill;
 
 				case SIDES.left:
-				/* ...str */
-				return utils.eatStr.cache[key] =
-				fill + $.trim(str.substr(bite_size));
+					/* ...str */
+					return utils.eatStr.cache[key] =
+							fill + $.trim(str.substr(bite_size));
 
 				case SIDES.center:
-				/* Bit-shift to the right by one === Math.floor(x / 2) */
-				half_length = length >> 1; // halve the length
-				half_bite_size = bite_size >> 1; // halve the bite_size
+					/* Bit-shift to the right by one === Math.floor(x / 2) */
+					half_length = length >> 1; // halve the length
+					half_bite_size = bite_size >> 1; // halve the bite_size
 
-				/* st...r */
-				return utils.eatStr.cache[key] =
-				$.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
-				fill +
-				$.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
+					/* st...r */
+					return utils.eatStr.cache[key] =
+							$.trim(utils.eatStr(str.substr(0, length - half_length), SIDES.right, bite_size - half_bite_size, '')) +
+							fill +
+							$.trim(utils.eatStr(str.substr(length - half_length), SIDES.left, half_bite_size, ''));
 
 				default:
-				$.error('Invalid side "' + side + '".');
+					$.error('Invalid side "' + side + '".');
 			}
 		},
 
 		getLineHeight: function (elem) {
-			var html = $(elem).html();
+				var html = $(elem).html();
 
-			/* Set the content to a small single character and wrap. */
-			$(elem).html('i');
+				/* Set the content to a small single character and wrap. */
+				$(elem).html('i');
 
-			/* Calculate the line height by measuring the wrapper.*/
-			var line_height = utils.getHeight($(elem));
+				/* Calculate the line height by measuring the wrapper.*/
+				var line_height = utils.getHeight($(elem));
 
-			/* Reset the content. */
-			$(elem).html(html);
+				/* Reset the content. */
+				$(elem).html(html);
 
-			return line_height;
+				return line_height;
 		},
 
 		getHeight: function(elem) {

--- a/trunk8.js
+++ b/trunk8.js
@@ -21,11 +21,11 @@
 		},
 		WIDTH = {
 			auto: 'auto'
-	};
+		};
 
 	function trunk8(element) {
 		this.$element = $(element);
-		this.original_text = $.trim(this.$element.html();
+		this.original_text = $.trim(this.$element.html());
 		this.settings = $.extend({}, $.fn.trunk8.defaults);
 	}
 
@@ -51,7 +51,7 @@
 			return str.split(/\s/g);
 		}
 		var allResults = [],
-			reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>)*)<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
+			reg = /<([a-z]+)([^<]*)(?:>(.*?(?!<\1>))<\/\1>|\s+\/>)(['.?!,]*)|((?:[^<>\s])+['.?!,]*\w?|<br\s?\/?>)/ig,
 			outArr = reg.exec(str),
 			lastI,
 			ind;
@@ -71,7 +71,7 @@
 		}
 		for (ind = 0; ind < allResults.length; ind++) {
 			if (typeof allResults[ind] !== 'string' &&
-				allResults[ind].content) {
+					allResults[ind].content) {
 				allResults[ind].content = getHtmlArr(allResults[ind].content);
 			}
 		}
@@ -96,7 +96,7 @@
 					biteLength = $.trim(bite).split(' ').length;
 					if ($.trim(bite).length) {
 						if (typeof content === 'string') {
-							if (!/<br\s*\/?>/.test(content)) {
+							if (!/<br\s*\/?>/i.test(content)) {
 								if (biteLength === 1 && $.trim(bite).length <= content.length) {
 									content = bite;
 									// We want the fill to go inside of the last HTML
@@ -107,8 +107,8 @@
 									bite = '';
 								} else {
 									bite = bite.replace(content, '');
+								}
 							}
-						}
 							retStr += $.trim(content) + ((i === contentArr.length-1 || biteLength <= 1) ? '' : ' ');
 						} else {
 							biteContent = biteHelper(content.content, content.tag);


### PR DESCRIPTION
This adds support for truncation in hidden elements, so that truncation doesn't cause page 'jumps'. After truncating the hidden element, the element will be cloned and the original rendered content will be overwritten. See README.md for a short explanation.
