### PR TITLE
Word Wrap

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -48,6 +48,10 @@
 		</div>
 		
 		<div>
+			<label>Word Wrap<input type="checkbox" id="wordWrap" checked/></label>
+		</div>
+		
+		<div>
 			<label>
 				Fill
 				
@@ -147,7 +151,22 @@ $(document).ready(function () {
 		$('#txt').trunk8({fill: this.value});
 		updateSettings($('#txt').trunk8('getSettings'));
 	});
+
+	$('#wordWrap').change(function () {
+		/* Get current settings. */
+		var settings = $('#txt').trunk8('getSettings');
+
+		/* Decrement the line count no lower than 1. */
+		settings.wordWrap = !settings.wordWrap
+
+		/* Save the new setting. */
+		$('#txt').trunk8({wordWrap: settings.wordWrap});
+
+		/* Update the UI. */
+		updateSettings(settings);
+	});
 });
+
 		</script>
 	</body>
 </html>

--- a/demo.html
+++ b/demo.html
@@ -48,7 +48,7 @@
 		</div>
 		
 		<div>
-			<label>Word Wrap<input type="checkbox" id="wordWrap" checked/></label>
+			<label>Word Wrap<input type="checkbox" id="wordWrap"/></label>
 		</div>
 		
 		<div>

--- a/trunk8.js
+++ b/trunk8.js
@@ -131,6 +131,28 @@
 
 		return htmlResults;
 	}
+	
+	function wrapWord(regexp, str, fill, side){
+		
+		switch (side) {
+				case SIDES.right:
+					return regexp.exec(str)[0] + fill;
+				case SIDES.left:					
+					return fill + regexp.exec(str.split("").reverse().join(""))[0].split("").reverse().join("");
+				case SIDES.center:
+				default:
+					$.error('Invalid side "' + side + '".');
+			}
+		
+		//TODO side.right / side.left
+		var result = '';
+		if(side == SIDES.left)
+			result = fill + match[0];
+		else
+			result = match[0] + fill;
+					
+		return result;
+	}
 
 	function truncate() {
 		var data = this.data('trunk8'),
@@ -196,23 +218,21 @@
 					max_bite = (max_bite.length > bite.length) ? max_bite : bite;
 				}
 			}
+			
+			if(settings.wordWrap){
+				//https://regex101.com/r/eB1aK8/1
+
+				var wrapBiteSize = max_bite.replace(fill, '').length;
+				var regexp = new RegExp("\^(.{1," + wrapBiteSize + "}(?=(\\W|$))|\^.{1," + wrapBiteSize + "})", "gmi");
+				
+				max_bite = wrapWord(regexp, str, fill, settings.side);
+			}
 
 			/* Reset the content to eliminate possible existing scroll bars. */
 			this.html('');
 			
 			/* Display the biggest bite. */
 			this.html(max_bite);
-			
-			if(settings.wordWrap){
-				//https://regex101.com/r/eB1aK8/1
-				
-				var wrapBiteSize = max_bite.replace(fill, '').length;
-				var regexp = new RegExp("\^(.{1," + wrapBiteSize + "}(?=(\\W|$))|\^.{1," + wrapBiteSize + "})", "gmi");
-				var match = regexp.exec(str);
-				this.html('');
-				//TODO side.right / side.left
-				this.html($.trim(match[0]) + fill);
-			}
 			
 			if (settings.tooltip) {
 				this.attr('title', text);

--- a/trunk8.js
+++ b/trunk8.js
@@ -205,14 +205,13 @@
 			
 			if(settings.wordWrap){
 				//https://regex101.com/r/eB1aK8/1
-				var max_bite_size = max_bite.length;
-				var regexp = new RegExp("(.{1,"+max_bite_size+"}([\\S])(?=(\\s))|.{1,"+max_bite_size+"})", "gmi");
 				
-				var match = regexp.exec(max_bite.replace(fill, ''));
-				
+				var wrapBiteSize = max_bite.replace(fill, '').length;
+				var regexp = new RegExp("\^(.{1," + wrapBiteSize + "}(?=(\\W|$))|\^.{1," + wrapBiteSize + "})", "gmi");
+				var match = regexp.exec(str);
 				this.html('');
 				//TODO side.right / side.left
-				this.html(match[0] + fill);
+				this.html($.trim(match[0]) + fill);
 			}
 			
 			if (settings.tooltip) {
@@ -285,6 +284,10 @@
 	};
 
 	utils = {
+		wordWrap: function(str, side, bite_size, fill){
+			
+		},
+		
 		/** Replaces [bite_size] [side]-most chars in [str] with [fill]. */
 		eatStr: function (str, side, bite_size, fill) {
 			var length = str.length,

--- a/trunk8.js
+++ b/trunk8.js
@@ -139,6 +139,7 @@
 			side = settings.side,
 			fill = settings.fill,
 			parseHTML = settings.parseHTML,
+			wordWrap = settings.wordWrap,
 			line_height = utils.getLineHeight(this) * settings.lines,
 			str = data.original_text,
 			length = str.length,
@@ -201,6 +202,18 @@
 			
 			/* Display the biggest bite. */
 			this.html(max_bite);
+			
+			if(settings.wordWrap){
+				//https://regex101.com/r/eB1aK8/1
+				var max_bite_size = max_bite.length;
+				var regexp = new RegExp("(.{1,"+max_bite_size+"}([\\S])(?=(\\s))|.{1,"+max_bite_size+"})", "gmi");
+				
+				var match = regexp.exec(max_bite.replace(fill, ''));
+				
+				this.html('');
+				//TODO side.right / side.left
+				this.html(match[0] + fill);
+			}
 			
 			if (settings.tooltip) {
 				this.attr('title', text);
@@ -379,6 +392,7 @@
 		tooltip: true,
 		width: WIDTH.auto,
 		parseHTML: false,
-		onTruncate: function () {}
+		onTruncate: function () {},
+		wordWrap: true
 	};
 })(jQuery);


### PR DESCRIPTION
Truncating words in anywhere can cause that potentially offensive or unpleasant words be displayed. With WordWrap function, this Regexp will keep the text within the desired box, but truncating only whole words.
I will use it in a project that demands that the truncated texts don't break apart within words.

About line 296 on `trnuk8.js`, I'm not actually proud of it, but I could only see this solution for reversing the string and then reversing back after applying the regex.
