### PR TITLE
lines: 'auto' for css max-height:val and overflow:hidden elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Settings
 --------
 
 * **fill** _(Default: '`&hellip;`')_ The string to insert in place of the omitted text. This value may include HTML.
-* **lines** _(Default: `1`)_ The number of lines of text-wrap to tolerate before truncating. This value must be an integer greater than or equal to 1.
+* **lines** _(Default: `1`)_ The number of lines of text-wrap to tolerate before truncating. When set to `'auto`', trunk8 will use the height of the element.
 * **side** _(Default: `'right'`)_ The side of the text from which to truncate. Valid values include `'center'`, `'left'`, and `'right'`.
 * **tooltip** _(Default: `true`)_ When true, the `title` attribute of the targeted HTML element will be set to the original, untruncated string. Valid values include `true` and `false`.
 * **width** _(Default: `'auto'`)_ The width, in characters, of the desired text. When set to `'auto'`, trunk8 will maximize the amount of text without spilling over.

--- a/demo.html
+++ b/demo.html
@@ -10,6 +10,19 @@
 				width: 676px;
 			}
 			
+			#trunk8-responsive {
+				border: 2px solid #000;
+				line-height: 20px;
+				max-height: 20px;
+				overflow: hidden;
+			}
+			
+			@media (max-width: 767px) {
+				#trunk8-responsive {
+					max-height: 40px;
+				}
+			}
+			
 			.trunk8-fill {
 				color: #f00;
 				font-weight: bold;
@@ -64,19 +77,45 @@
 			<pre id="settings"></pre>
 		</div>
 		
+		
+		<div id="trunk8-responsive">
+				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+		</div>
+		
+		<div>
+			<pre id="css-responsive">
+#trunk8-responsive {
+  border: 2px solid #000;
+  line-height: 20px;
+  max-height: 20px;
+  overflow: hidden;
+}
+
+@media (max-width: 767px) {
+  #trunk8-responsive {
+    max-height: 40px;
+  }
+}
+			</pre>
+			<pre id="settings-responsive"></pre>
+		</div>
+		
+		
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 		<script src="trunk8.js"></script>
 		<script>
 $(document).ready(function () {
-	function updateSettings(settings) {
+	function updateSettings(settings, id) {
 		var props = [],
 			prop;
+			debugger;
+		id = id || "#settings";
 
 		for (prop in settings) {
 			props.push('    '+prop+': '+settings[prop]);
 		}
 
-		$('#settings').html('settings = {<br/>' + props.join(',<br/>') + '<br/>}');
+		$(id).html('settings = {<br/>' + props.join(',<br/>') + '<br/>}');
 	}
 	
 	$('#txt').trunk8();
@@ -147,6 +186,13 @@ $(document).ready(function () {
 		$('#txt').trunk8({fill: this.value});
 		updateSettings($('#txt').trunk8('getSettings'));
 	});
+	
+	// Responsive
+	$('#trunk8-responsive').trunk8({lines: 'auto'});
+	
+	$(window).resize(function() { $('#trunk8-responsive').trunk8('update'); });
+	
+	updateSettings($('#trunk8-responsive').trunk8('getSettings'), "#settings-responsive");
 });
 		</script>
 	</body>

--- a/trunk8.js
+++ b/trunk8.js
@@ -20,7 +20,7 @@
 			right: 'right'
 		},
 		LINES = {
-		    auto: 'auto'
+			auto: 'auto'
 		},
 		WIDTH = {
 			auto: 'auto'
@@ -136,7 +136,7 @@
 	}
 
 	function truncate() {
-	    var data = this.data('trunk8'),
+		var data = this.data('trunk8'),
 			settings = data.settings,
 			width = settings.width,
 			side = settings.side,
@@ -146,7 +146,7 @@
 			str = data.original_text,
 			length = str.length,
 			max_bite = '',
-            line_height, get_height,
+			line_height, get_height,
 			lower, upper,
 			bite_size,
 			bite,
@@ -158,15 +158,15 @@
 		text = this.text();
 
 		if (lines === LINES.auto) {
-		    line_height = this.height();
-		    get_height = function (obj) { return $(obj).prop('scrollHeight'); }
+			line_height = this.height();
+			get_height = function (obj) { return $(obj).prop('scrollHeight'); }
 		} else if (!isNaN(lines)) {
-		    line_height = utils.getLineHeight(this) * lines;
-		    get_height = function (obj) { return $(obj).height(); }
+			line_height = utils.getLineHeight(this) * lines;
+			get_height = function (obj) { return $(obj).height(); }
 		} else {
-		    $.error('Invalid lines "' + lines + '".');
-		    return;
-        }
+			$.error('Invalid lines "' + lines + '".');
+			return;
+		}
 		
 
 		/* If string has HTML and parse HTML is set, build */
@@ -182,10 +182,10 @@
 			//if (this.height() <= line_height) {
 			//	/* Text is already at the optimal trunkage. */
 			//	return;
-		    //}
-		    if (get_height(this) <= line_height) {
-		        return;
-		    }
+			//}
+			if (get_height(this) <= line_height) {
+				return;
+			}
 
 			/* Binary search technique for finding the optimal trunkage. */
 			/* Find the maximum bite without overflowing. */
@@ -204,7 +204,7 @@
 				this.html(bite);
 
 				/* Check for overflow. */
-			    //if (this.height() > line_height) {
+				//if (this.height() > line_height) {
 				if (get_height(this) > line_height) {
 					upper = bite_size - 1;
 				}

--- a/trunk8.js
+++ b/trunk8.js
@@ -19,6 +19,9 @@
 			/* right... */
 			right: 'right'
 		},
+		LINES = {
+		    auto: 'auto'
+		},
 		WIDTH = {
 			auto: 'auto'
 		};
@@ -133,16 +136,17 @@
 	}
 
 	function truncate() {
-		var data = this.data('trunk8'),
+	    var data = this.data('trunk8'),
 			settings = data.settings,
 			width = settings.width,
 			side = settings.side,
 			fill = settings.fill,
 			parseHTML = settings.parseHTML,
-			line_height = utils.getLineHeight(this) * settings.lines,
+			lines = settings.lines,
 			str = data.original_text,
 			length = str.length,
 			max_bite = '',
+            line_height, get_height,
 			lower, upper,
 			bite_size,
 			bite,
@@ -153,6 +157,18 @@
 		this.html(str);
 		text = this.text();
 
+		if (lines === LINES.auto) {
+		    line_height = this.height();
+		    get_height = function (obj) { return $(obj).prop('scrollHeight'); }
+		} else if (!isNaN(lines)) {
+		    line_height = utils.getLineHeight(this) * lines;
+		    get_height = function (obj) { return $(obj).height(); }
+		} else {
+		    $.error('Invalid lines "' + lines + '".');
+		    return;
+        }
+		
+
 		/* If string has HTML and parse HTML is set, build */
 		/* the data struct to house the tags */
 		if (parseHTML && stripHTML(str) !== str) {
@@ -160,13 +176,16 @@
 			str = stripHTML(str);
 			length = str.length;
 		}
-
+		
 		if (width === WIDTH.auto) {
 			/* Assuming there is no "overflow: hidden". */
-			if (this.height() <= line_height) {
-				/* Text is already at the optimal trunkage. */
-				return;
-			}
+			//if (this.height() <= line_height) {
+			//	/* Text is already at the optimal trunkage. */
+			//	return;
+		    //}
+		    if (get_height(this) <= line_height) {
+		        return;
+		    }
 
 			/* Binary search technique for finding the optimal trunkage. */
 			/* Find the maximum bite without overflowing. */
@@ -185,7 +204,8 @@
 				this.html(bite);
 
 				/* Check for overflow. */
-				if (this.height() > line_height) {
+			    //if (this.height() > line_height) {
+				if (get_height(this) > line_height) {
 					upper = bite_size - 1;
 				}
 				else {
@@ -349,7 +369,7 @@
 	
 				/* Remove the wrapper and reset the content. */
 				$(elem).html(html).css({ 'float': floats, 'position': pos }).unwrap();
-	
+				
 				return line_height;
 			}
 	};


### PR DESCRIPTION
Includes basic ability to determine `line_height` from `.el { max-height: val; overflow:hidden }`.

If `lines` is set to `'auto'` we use $(element).height() as the `line_height` and use `$(element).prop('scrollHeight')` as the content height. Otherwise default (previous) behaviour is used.

Default value of `lines` is still `1`.

Check the demo. This works 'fine for me'. Thanks a lot for this plugin, it's very efficient.

Feedback/improvements welcomed.
